### PR TITLE
Fix force scrolling to the top repeatedly when use 'Always use "Follwing" Tab'

### DIFF
--- a/content-scripts/src/modules/options/timeline.js
+++ b/content-scripts/src/modules/options/timeline.js
@@ -249,7 +249,7 @@ export const changeRecentMedia = async (recentMedia) => {
                 top: 70px;
                 width: 300px;
               }
-              
+
               [data-testid="primaryColumn"] {
                 transform: translateX(-64px);
               }
@@ -339,9 +339,11 @@ export const changeFollowingTimeline = (followingTimeline) => {
   // Check if there's a selected tab
   if (!tablist || !selectedTab) return;
 
+  // get localized "Following" text
+  const secondTabText = tablist.querySelector("div[role='presentation']:nth-of-type(2) span").textContent.toLowerCase();
   const selectedTabText = selectedTab.querySelector("div[dir='ltr'] > span").textContent.toLowerCase();
 
-  if (selectedTabText === "following") return;
+  if (secondTabText === selectedTabText) return;
 
   const secondTab = tablist.querySelector("div[role='presentation']:nth-child(2) a");
 


### PR DESCRIPTION
The original implementation uses the literal "following" string to detect the "Following" tab, but the string is localized to some strings in a non-English locale.
For instance, the "Following" tab is localized to **"フォロー中"** in Japanese locale.

[![Image from Gyazo](https://i.gyazo.com/28bf8ff4df4da36dc415bcca6f23407e.png)](https://gyazo.com/28bf8ff4df4da36dc415bcca6f23407e)

In this PR, use localized "following" text from DOM to check "following" tab is selected.

fix #209, #206