### PR TITLE
Send hide view count data from local storage to changeHideViewCounts

### DIFF
--- a/content-scripts/src/modules/features/dynamic.js
+++ b/content-scripts/src/modules/features/dynamic.js
@@ -12,6 +12,7 @@ import {
   KeyCommunitiesButton,
   KeyFollowingTimeline,
   KeyHideGrokDrawer,
+  KeyHideViewCount,
   KeyListsButton,
   KeyRemoveTimelineTabs,
   KeyTopicsButton,
@@ -32,8 +33,10 @@ import { getStorage } from "../utilities/storage";
 import throttle from "../utilities/throttle";
 
 export const dynamicFeatures = {
-  general: () => {
-    changeHideViewCounts();
+  general: async () => {
+    const data = await getStorage([KeyHideViewCount]);
+
+    changeHideViewCounts(data[KeyHideViewCount]);
     changeRecentMedia();
     hideRightSidebar();
     addSmallerSearchBarStyle();


### PR DESCRIPTION
This PR fixes the issue of remove view count setting not being picked up on page refresh.

Fix MIN-23

Fixes https://github.com/typefully/minimal-twitter/issues/221