### PR TITLE
Fix search bar getting collapsed when search items are cleared

### DIFF
--- a/content-scripts/src/modules/utilities/other-styles.js
+++ b/content-scripts/src/modules/utilities/other-styles.js
@@ -1,5 +1,5 @@
 import selectors from "../../selectors";
-import addStyles from "./addStyles";
+import addStyles, { removeStyles } from "./addStyles";
 
 export const addSmallerSearchBarStyle = () => {
   const searchInput = document.querySelector(selectors.searchBoxInput);
@@ -18,4 +18,40 @@ export const addSmallerSearchBarStyle = () => {
       width: ${searchBarPlaceholderWidth + 4}ch;
     }`
   );
+
+  handleSidebarSearchWidthStyle();
+};
+
+const handleSidebarSearchWidthStyle = () => {
+  const sidebarSearchForm = document.querySelector(selectors.searchBox);
+
+  if (sidebarSearchForm) {
+    const applyWidthStyle = () => {
+      addStyles(
+        "sidebarSearchWidth",
+        `${selectors.searchBox} { width: 374px; }`
+      );
+    };
+
+    // Check if listbox is currently visible (form has focus)
+    const listBox = document.querySelector(selectors.searchListBox);
+    if (listBox) {
+      applyWidthStyle();
+    }
+
+    sidebarSearchForm.addEventListener('focusin', applyWidthStyle);
+    
+    sidebarSearchForm.addEventListener('click', (e) => {
+      const clickedListbox = e.target.closest('[role="listbox"]');
+      if (clickedListbox) {
+        applyWidthStyle();
+      }
+    });
+
+    document.addEventListener('click', (e) => {
+      if (!e.target.closest(selectors.searchBox)) {
+        removeStyles("sidebarSearchWidth");
+      }
+    });
+  }
 };

--- a/content-scripts/src/selectors.js
+++ b/content-scripts/src/selectors.js
@@ -43,6 +43,7 @@ selectors.tweetSpan = `${selectors.tweet} div > div:only-child > span:only-child
 // Search
 selectors.searchBox = `${selectors.rightSidebar} form[role="search"]`;
 selectors.searchBoxInput = `${selectors.searchBox} input:only-child`;
+selectors.searchListBox = `${selectors.searchBox} div[role="listbox"]`;
 // Modals
 selectors.modalExternalWrapper = `div[role="group"]`;
 selectors.modalBackground = `${selectors.modalExternalWrapper} > div:empty`;


### PR DESCRIPTION
Fix issue where search bar shrinks when clearing past searches

[CleanShot 2025-02-25 at 23.01.53.mp4 <span class="graphite__hidden">(uploaded via Graphite)</span> <img class="graphite__hidden" src="https://app.graphite.dev/api/v1/graphite/video/thumbnail/XLCshj12FUjKXyCRCqoU/a34d20ce-8b13-450a-aa95-1f8699f376d8.mp4" />](https://app.graphite.dev/media/video/XLCshj12FUjKXyCRCqoU/a34d20ce-8b13-450a-aa95-1f8699f376d8.mp4)

Fix MIN-12