### PR TITLE
Use Typefully callout for save draft to Typefully button from post modal

### DIFF
--- a/content-scripts/src/modules/options/typefully.js
+++ b/content-scripts/src/modules/options/typefully.js
@@ -11,7 +11,7 @@ export const changeTypefullyComposerButtons = (typefullyComposerButtons) => {
         #typefully-link-inline,
         #typefully-reply-link, 
         #typefully-writermode-link, 
-        #typefully-writermode-box {
+        #typefully-callout-box {
           display: none;
         }
         `

--- a/content-scripts/src/modules/options/writerMode.js
+++ b/content-scripts/src/modules/options/writerMode.js
@@ -5,7 +5,6 @@ import { createTypefullyLinkElement, createTypefullyLogo, getCurrentTextAndSendT
 import addStyles, { removeStyles, stylesExist } from "../utilities/addStyles";
 import addTooltip, { hideAllTooltips } from "../utilities/addTooltip";
 import addTypefullyBox from "../utilities/addTypefullyBox";
-import { createTypefullyUrl } from "../utilities/createTypefullyUrl";
 import { getStorage, setStorage } from "../utilities/storage";
 
 const escKeyListener = async (event) => {
@@ -130,21 +129,9 @@ export const addTypefullyPlugToWriterMode = async () => {
     typefullyLinkElement.appendChild(typefullyText);
 
     /* ----------------- Typefully box callout with explanation ---------------- */
-
-    const url = createTypefullyUrl({
-      utm_content: "writer-mode-callout",
-    });
-
     addTypefullyBox(
       main,
-      "writer-mode",
-      `<ul>
-  <li>💬 Share your drafts and get comments</li>
-  <li>🤖 Improve your tweets with AI</li>
-  <li>📈 Track your growth with insights and metrics</li>
-  <li>📆 Schedule for later</li>
-</ul>
-<p>Powered by <a href="${url}" target="_blank">Typefully</a>, the makers of the Minimal Twitter extension.</p>`,
+      "writer-mode-callout",
       {
         withArrow: true,
       }
@@ -158,7 +145,7 @@ export const removeTypefullyPlugFromWriterMode = () => {
   const typefullyLinkElement = document.getElementById("typefully-writermode-link");
   typefullyLinkElement && typefullyLinkElement.remove();
 
-  const typefullyBox = document.getElementById("typefully-writermode-box");
+  const typefullyBox = document.getElementById("typefully-callout-box");
   typefullyBox && typefullyBox.remove();
 };
 

--- a/content-scripts/src/modules/typefullyPlugs.js
+++ b/content-scripts/src/modules/typefullyPlugs.js
@@ -3,6 +3,7 @@ import addStyles, { removeStyles } from "./utilities/addStyles";
 import addTooltip from "./utilities/addTooltip";
 import { createTypefullyUrl } from "./utilities/createTypefullyUrl";
 import { removeElementById } from "./utilities/removeElement";
+import addTypefullyBox from "./utilities/addTypefullyBox";
 
 const MODAL_PLUG_ID = "typefully-link";
 const INLINE_PLUG_ID = "typefully-link-inline";
@@ -33,12 +34,16 @@ export const addTypefullyComposerPlug = () => {
     typefullyText.innerText = "Save draft to Typefully";
     element.appendChild(typefullyLogo);
     element.appendChild(typefullyText);
-    modal.appendChild(element);
 
-    addTooltip(element, {
-      id: "typefully-tooltip",
-      description: "Save all your post ideas, enhance with AI, schedule, and boost engagement.",
-    });
+    addTypefullyBox(
+      modal,
+      "save-draft-callout",
+      {
+        withArrow: true,
+      }
+    );
+
+    modal.appendChild(element);
   }
 
   if (tweetButtonInlineDisabled && document.getElementById(INLINE_PLUG_ID)) {

--- a/content-scripts/src/modules/utilities/addTypefullyBox.js
+++ b/content-scripts/src/modules/utilities/addTypefullyBox.js
@@ -1,16 +1,29 @@
 import svgAssets from "../svgAssets";
 import { getStorage, setStorage } from "./storage";
+import { createTypefullyUrl } from "./createTypefullyUrl";
 
-export default async function addTypefullyBox(rootElement, storageKey, innerHTML, options = {}) {
+export default async function addTypefullyBox(rootElement, utmContent, options = {}) {
   const { withArrow } = options ?? {};
 
-  const key = "tp-box-seen:" + storageKey;
+  const key = "tp-box-seen:typefully-callout";
 
   const seen = await getStorage(key);
 
+  const url = createTypefullyUrl({
+    utm_content: utmContent,
+  });
+
+  const innerHTML = `<ul>
+  <li>💬 Share your drafts and get comments</li>
+  <li>🤖 Improve your tweets with AI</li>
+  <li>📈 Track your growth with insights and metrics</li>
+  <li>📆 Schedule for later</li>
+</ul>
+<p>Powered by <a href="${url}" target="_blank">Typefully</a>, the makers of the Minimal Twitter extension.</p>`;
+
   if (seen !== "true") {
     const typefullyBox = document.createElement("div");
-    typefullyBox.id = "typefully-writermode-box";
+    typefullyBox.id = "typefully-callout-box";
     typefullyBox.className = "typefully-box";
 
     typefullyBox.innerHTML = innerHTML;

--- a/css/typefully.css
+++ b/css/typefully.css
@@ -18,7 +18,6 @@
   justify-content: center;
   align-items: center;
   margin: 20px auto;
-  order: 99;
   z-index: 2;
   cursor: pointer;
 }
@@ -48,7 +47,7 @@ body.mt-writerMode-on .typefully-save-draft-button {
 #typefully-link-inline,
 #typefully-reply-link,
 #typefully-writermode-link,
-#typefully-writermode-box {
+#typefully-callout-box {
   visibility: visible;
 }
 
@@ -78,13 +77,13 @@ body.mt-writerMode-on .typefully-save-draft-button {
   }
 }
 
-#typefully-writermode-box {
+#typefully-callout-box {
   font-family: TwitterChirp, -apple-system, BlinkMacSystemFont, "Segoe UI",
     Roboto, Helvetica, Arial, sans-serif;
   color: var(--main-text-color);
   width: auto;
   max-width: 100%;
-  --bg-color: rgba(var(--secondary-text-color-rgb), 0.08);
+  --bg-color: #f2f3f4;
   background: var(--bg-color);
   border-radius: 20px;
   padding: 6px 20px;
@@ -94,32 +93,32 @@ body.mt-writerMode-on .typefully-save-draft-button {
   order: 2;
 }
 
-#typefully-writermode-box h3,
-#typefully-writermode-box p {
+#typefully-callout-box h3,
+#typefully-callout-box p {
   margin: 10px 0;
 }
 
-#typefully-writermode-box p,
-#typefully-writermode-box li {
+#typefully-callout-box p,
+#typefully-callout-box li {
   color: var(--secondary-text-color);
 }
 
-#typefully-writermode-box ul {
+#typefully-callout-box ul {
   margin: 14px 0;
   padding-left: 0px;
   list-style: none;
 }
 
-#typefully-writermode-box li {
+#typefully-callout-box li {
   margin: 6px 0;
 }
 
-#typefully-writermode-box a {
+#typefully-callout-box a {
   color: var(--accent-color);
   text-decoration: none;
 }
 
-#typefully-writermode-box #box-close-button {
+#typefully-callout-box #box-close-button {
   position: absolute;
   top: 18px;
   right: 18px;
@@ -128,11 +127,11 @@ body.mt-writerMode-on .typefully-save-draft-button {
   color: var(--secondary-text-color);
 }
 
-#typefully-writermode-box #box-close-button:hover {
+#typefully-callout-box #box-close-button:hover {
   opacity: 1;
 }
 
-#typefully-writermode-box #box-arrow {
+#typefully-callout-box #box-arrow {
   position: absolute;
   top: -12px;
   line-height: 0;
@@ -152,11 +151,11 @@ body.mt-writerMode-on .typefully-save-draft-button {
   }
 }
 
-#typefully-writermode-box {
+#typefully-callout-box {
   animation: fadeIn 0.3s ease-out both;
 }
 
-#typefully-writermode-box {
+#typefully-callout-box {
   animation-delay: 0.1s;
 }
 


### PR DESCRIPTION
### TL;DR
Unified the Typefully callout box implementation across writer mode and composer plugs.

### What changed?
- Renamed `typefully-writermode-box` to `typefully-callout-box` since the same is being used in zen mode as well as on the `Save draft to Typefully` button in post modal.
- Refactor `addTypefullyBox` function.
- Set a fixed background color (#f2f3f4) instead of using CSS variables
- Closing callout at one place should dismiss it from appearing at other places

### How to test?
1. Open Twitter and enter writer mode
2. Verify the callout box appears with correct styling
3. Check the composer plug shows the same callout box
4. Confirm the close button works and remembers state
5. Verify links open correctly with proper UTM parameters
6. Click on post and verify if the callout shows up below `Save draft to Typefully` button.

### Why make this change?
Use Typefully callout in the post modal on the `Save draft to Typefully` button.

[demo 1.mp4 <span class="graphite__hidden">(uploaded via Graphite)</span> <img class="graphite__hidden" src="https://app.graphite.dev/api/v1/graphite/video/thumbnail/XLCshj12FUjKXyCRCqoU/a3d612ab-1155-4284-aa29-ee39cee63dec.mp4" />](https://app.graphite.dev/media/video/XLCshj12FUjKXyCRCqoU/a3d612ab-1155-4284-aa29-ee39cee63dec.mp4)
[demo 2.mp4 <span class="graphite__hidden">(uploaded via Graphite)</span> <img class="graphite__hidden" src="https://app.graphite.dev/api/v1/graphite/video/thumbnail/XLCshj12FUjKXyCRCqoU/b2421eff-03e3-4467-bf35-a61cf04a3d43.mp4" />](https://app.graphite.dev/media/video/XLCshj12FUjKXyCRCqoU/b2421eff-03e3-4467-bf35-a61cf04a3d43.mp4)

Fix MIN-18