### PR TITLE
Typefully plug in security and account access settings page

### DIFF
--- a/content-scripts/src/modules/features/dynamic.js
+++ b/content-scripts/src/modules/features/dynamic.js
@@ -25,7 +25,7 @@ import changeHideViewCounts from "../options/hideViewCount";
 import { addAnalyticsButton, addCommunitiesButton, addListsButton, addTopicsButton, addXPremiumButton, hideGrokDrawer } from "../options/navigation";
 import { changeFollowingTimeline, changeRecentMedia, changeTimelineTabs, changeTrendsHomeTimeline } from "../options/timeline";
 import { changeWriterMode } from "../options/writerMode";
-import { addTypefullyComposerPlug, addTypefullyReplyPlug, saveCurrentReplyToLink } from "../typefullyPlugs";
+import { addTypefullyComposerPlug, addTypefullyReplyPlug, saveCurrentReplyToLink, addTypefullySecurityAndAccountAccessPlug } from "../typefullyPlugs";
 import hideRightSidebar from "../utilities/hideRightSidebar";
 import { updateLeftSidebarPositioning } from "../utilities/leftSidebarPosition";
 import { addSmallerSearchBarStyle } from "../utilities/other-styles";
@@ -46,6 +46,7 @@ export const dynamicFeatures = {
     saveCurrentReplyToLink();
     addTypefullyReplyPlug();
     addTypefullyComposerPlug();
+    addTypefullySecurityAndAccountAccessPlug();
   },
   sidebarButtons: async () => {
     const data = await getStorage([KeyListsButton, KeyCommunitiesButton, KeyTopicsButton, KeyXPremiumButton, KeyTypefullyGrowTab]);

--- a/content-scripts/src/modules/features/static.js
+++ b/content-scripts/src/modules/features/static.js
@@ -44,7 +44,7 @@ import {
   KeyTransparentSearch,
   KeyTrendsHomeTimeline,
   KeyTweetButton,
-  KeyTypefullyComposerButtons,
+  KeyTypefullyEnhancementsButtons,
   KeyTypefullyGrowTab,
   KeyUnreadCountBadge,
   KeyVerifiedOrgsButton,
@@ -90,7 +90,7 @@ import {
   changeTrendsHomeTimeline,
   changeTweetBorders,
 } from "../options/timeline";
-import { changeTypefullyComposerButtons } from "../options/typefully";
+import { changeTypefullyEnhancementsButtons } from "../options/typefully";
 import { changeWriterMode } from "../options/writerMode";
 
 export const staticFeatures = {
@@ -107,7 +107,7 @@ export const staticFeatures = {
     changePromotedPosts(data[KeyRemovePromotedPosts]);
     changeTopicsToFollow(data[KeyRemoveTopicsToFollow]);
     changeTimelineTabs(data[KeyRemoveTimelineTabs], data[KeyWriterMode]);
-    changeTypefullyComposerButtons(data[KeyTypefullyComposerButtons]);
+    changeTypefullyEnhancementsButtons(data[KeyTypefullyEnhancementsButtons]);
     changeFollowingAndFollowersCounts(data[KeyFollowCount]);
     changeReplyCount(data[KeyReplyCount]);
     changeRetweetCount(data[KeyRetweetCount]);

--- a/content-scripts/src/modules/options/typefully.js
+++ b/content-scripts/src/modules/options/typefully.js
@@ -1,11 +1,11 @@
 import addStyles, { removeStyles } from "../utilities/addStyles";
 
 // Function to change Typefully Composer Buttons
-export const changeTypefullyComposerButtons = (typefullyComposerButtons) => {
-  switch (typefullyComposerButtons) {
+export const changeTypefullyEnhancementsButtons = (typefullyEnhancementsButtons) => {
+  switch (typefullyEnhancementsButtons) {
     case "off":
       addStyles(
-        "typefullyComposerButtons",
+        "typefullyEnhancementsButtons",
         `
         #typefully-link, 
         #typefully-link-inline,
@@ -19,7 +19,7 @@ export const changeTypefullyComposerButtons = (typefullyComposerButtons) => {
       break;
 
     case "on":
-      removeStyles("typefullyComposerButtons");
+      removeStyles("typefullyEnhancementsButtons");
       break;
   }
 };

--- a/content-scripts/src/modules/options/writerMode.js
+++ b/content-scripts/src/modules/options/writerMode.js
@@ -6,6 +6,7 @@ import addStyles, { removeStyles, stylesExist } from "../utilities/addStyles";
 import addTooltip, { hideAllTooltips } from "../utilities/addTooltip";
 import addTypefullyBox from "../utilities/addTypefullyBox";
 import { getStorage, setStorage } from "../utilities/storage";
+import { createTypefullyUrl } from "../utilities/createTypefullyUrl";
 
 const escKeyListener = async (event) => {
   if (event.key === "Escape") {
@@ -129,9 +130,21 @@ export const addTypefullyPlugToWriterMode = async () => {
     typefullyLinkElement.appendChild(typefullyText);
 
     /* ----------------- Typefully box callout with explanation ---------------- */
+    const url = createTypefullyUrl({
+      utm_content: "writer-mode-callout",
+    });
+
+    const innerHTML = `<ul>
+  <li>💬 Share your drafts and get comments</li>
+  <li>🤖 Improve your tweets with AI</li>
+  <li>📈 Track your growth with insights and metrics</li>
+  <li>📆 Schedule for later</li>
+</ul>
+<p>Powered by <a href="${url}" target="_blank">Typefully</a>, the makers of the Minimal Twitter extension.</p>`;
+
     addTypefullyBox(
       main,
-      "writer-mode-callout",
+      innerHTML,
       {
         withArrow: true,
       }

--- a/content-scripts/src/modules/typefullyPlugs.js
+++ b/content-scripts/src/modules/typefullyPlugs.js
@@ -168,6 +168,7 @@ export const addTypefullySecurityAndAccountAccessPlug = () => {
       securityAndAccountAccess,
       innerHTML,
       {
+        className: "typefully-teams-box",
         withArrow: false,
       }
     );

--- a/content-scripts/src/modules/typefullyPlugs.js
+++ b/content-scripts/src/modules/typefullyPlugs.js
@@ -1,3 +1,4 @@
+import selectors from "../selectors";
 import svgAssets from "./svgAssets";
 import addStyles, { removeStyles } from "./utilities/addStyles";
 import addTooltip from "./utilities/addTooltip";
@@ -35,9 +36,21 @@ export const addTypefullyComposerPlug = () => {
     element.appendChild(typefullyLogo);
     element.appendChild(typefullyText);
 
+    const url = createTypefullyUrl({
+      utm_content: "save-draft-callout",
+    });
+
+    const innerHTML = `<ul>
+  <li>💬 Share your drafts and get comments</li>
+  <li>🤖 Improve your tweets with AI</li>
+  <li>📈 Track your growth with insights and metrics</li>
+  <li>📆 Schedule for later</li>
+</ul>
+<p>Powered by <a href="${url}" target="_blank">Typefully</a>, the makers of the Minimal Twitter extension.</p>`;
+
     addTypefullyBox(
       modal,
-      "save-draft-callout",
+      innerHTML,
       {
         withArrow: true,
       }
@@ -139,6 +152,26 @@ export const addTypefullyReplyPlug = () => {
     }
     // A small delay so let the regular drag plug appear first, so we can replace it
   }, 100);
+};
+
+export const addTypefullySecurityAndAccountAccessPlug = () => {
+  const securityAndAccountAccess = document.querySelector(selectors.securityAndAccountAccess);
+
+  if (securityAndAccountAccess && !document.getElementById("typefully-callout-box")) {
+    const url = createTypefullyUrl({
+      utm_content: "typefully-teams-callout"
+    });
+
+    const innerHTML = `<p>You can use <a href="${url}" target="_blank">Typefully</a> to easily collaborate on multiple Twitter accounts with your team or clients and to share & comment on draft posts.</p>`;
+
+    addTypefullyBox(
+      securityAndAccountAccess,
+      innerHTML,
+      {
+        withArrow: false,
+      }
+    );
+  }
 };
 
 /* ----------------------------- Typefully Utils ---------------------------- */

--- a/content-scripts/src/modules/utilities/addTypefullyBox.js
+++ b/content-scripts/src/modules/utilities/addTypefullyBox.js
@@ -2,7 +2,7 @@ import svgAssets from "../svgAssets";
 import { getStorage, setStorage } from "./storage";
 
 export default async function addTypefullyBox(rootElement, innerHTML, options = {}) {
-  const { withArrow } = options ?? {};
+  const { withArrow, className } = options ?? {};
 
   const key = "tp-box-seen:typefully-callout";
 
@@ -11,7 +11,7 @@ export default async function addTypefullyBox(rootElement, innerHTML, options = 
   if (seen !== "true") {
     const typefullyBox = document.createElement("div");
     typefullyBox.id = "typefully-callout-box";
-    typefullyBox.className = "typefully-box";
+    typefullyBox.className = className ?? "typefully-box";
 
     typefullyBox.innerHTML = innerHTML;
 

--- a/content-scripts/src/modules/utilities/addTypefullyBox.js
+++ b/content-scripts/src/modules/utilities/addTypefullyBox.js
@@ -1,25 +1,12 @@
 import svgAssets from "../svgAssets";
 import { getStorage, setStorage } from "./storage";
-import { createTypefullyUrl } from "./createTypefullyUrl";
 
-export default async function addTypefullyBox(rootElement, utmContent, options = {}) {
+export default async function addTypefullyBox(rootElement, innerHTML, options = {}) {
   const { withArrow } = options ?? {};
 
   const key = "tp-box-seen:typefully-callout";
 
   const seen = await getStorage(key);
-
-  const url = createTypefullyUrl({
-    utm_content: utmContent,
-  });
-
-  const innerHTML = `<ul>
-  <li>💬 Share your drafts and get comments</li>
-  <li>🤖 Improve your tweets with AI</li>
-  <li>📈 Track your growth with insights and metrics</li>
-  <li>📆 Schedule for later</li>
-</ul>
-<p>Powered by <a href="${url}" target="_blank">Typefully</a>, the makers of the Minimal Twitter extension.</p>`;
 
   if (seen !== "true") {
     const typefullyBox = document.createElement("div");

--- a/content-scripts/src/selectors.js
+++ b/content-scripts/src/selectors.js
@@ -50,5 +50,7 @@ selectors.modalBackground = `${selectors.modalExternalWrapper} > div:empty`;
 selectors.modalWrapper = `div[aria-labelledby="modal-header"][role="dialog"]`;
 selectors.modalUi = `${selectors.modalWrapper} > div`;
 selectors.tweetButton = `[data-testid="SideNav_NewTweet_Button"]`;
+// Settings
+selectors.securityAndAccountAccess = `[data-testid="accountAccessScreen"]`;
 
 export default selectors;

--- a/css/typefully.css
+++ b/css/typefully.css
@@ -43,6 +43,10 @@ body.mt-writerMode-on .typefully-save-draft-button {
   margin: 0 3px 0 -8px;
 }
 
+.typefully-teams-box {
+  margin: 20px !important;
+}
+
 #typefully-link,
 #typefully-link-inline,
 #typefully-reply-link,

--- a/css/typefully.css
+++ b/css/typefully.css
@@ -86,7 +86,7 @@ body.mt-writerMode-on .typefully-save-draft-button {
   --bg-color: #f2f3f4;
   background: var(--bg-color);
   border-radius: 20px;
-  padding: 6px 20px;
+  padding: 6px 25px;
   line-height: 1.4;
   position: relative;
   margin: 8px auto 16px;

--- a/popup/components/sections/TypefullySection.js
+++ b/popup/components/sections/TypefullySection.js
@@ -6,7 +6,7 @@ const TypefullySection = () => (
   <section className="flex flex-col gap-y-2">
     <SectionLabel htmlFor="user-control-typefully">Typefully</SectionLabel>
     <ControlsWrapper id="user-control-typefully">
-      <SwitchControl label={`"Save to Typefully" in composers`} storageKey="typefullyComposerButtons" />
+      <SwitchControl label="Typefully Enhancements" storageKey="typefullyEnhancementsButtons" />
     </ControlsWrapper>
   </section>
 );

--- a/storage-keys.js
+++ b/storage-keys.js
@@ -38,7 +38,7 @@ export const KeyTransparentSearch = "transparentSearch";
 export const KeyRemovePromotedPosts = "removePromotedPosts";
 export const KeyRemoveTopicsToFollow = "removeTopicsToFollow";
 export const KeyRecentMedia = "recentMedia";
-export const KeyTypefullyComposerButtons = "typefullyComposerButtons";
+export const KeyTypefullyEnhancementsButtons = "typefullyEnhancementsButtons";
 export const KeyInterFont = "interFont";
 export const KeyTitleNotifications = "titleNotifications";
 export const KeyCustomCss = "customCss";
@@ -62,7 +62,7 @@ export const allSettingsKeys = [
   KeyRemovePromotedPosts,
   KeyRemoveTopicsToFollow,
   KeyRemoveTimelineTabs,
-  KeyTypefullyComposerButtons,
+  KeyTypefullyEnhancementsButtons,
   KeyFollowCount,
   KeyReplyCount,
   KeyRetweetCount,
@@ -124,7 +124,7 @@ export const defaultPreferences = {
   [KeyRemovePromotedPosts]: "on",
   [KeyRemoveTopicsToFollow]: "on",
   [KeyRemoveTimelineTabs]: "off",
-  [KeyTypefullyComposerButtons]: "on",
+  [KeyTypefullyEnhancementsButtons]: "on",
   [KeyFollowCount]: "on",
   [KeyReplyCount]: "on",
   [KeyRetweetCount]: "on",


### PR DESCRIPTION
### TL;DR
Added Typefully plug callout to the Security & Account Access page and renamed composer buttons setting to "Typefully Enhancements"

### What changed?
- Added a new Typefully callout box in the Security & Account Access page promoting team collaboration features
- Renamed "Save to Typefully in composers" setting to "Typefully Enhancements" for broader feature coverage
- Refactored Typefully box component to accept custom HTML content
- Updated styling for Typefully callout boxes

### How to test?
1. Navigate to Twitter Settings > Security and account access
2. Verify the Typefully teams callout appears
3. Check the extension popup and confirm the renamed setting
4. Turning off "Typefully Enhancements" should remove the callout.
5. Any callout that is closed should close all other callout's. Test by closing a callout in zen mode and check if the callout is closed in security & account access settings page.

### Why make this change?
To promote Typefully's team collaboration features in relevant contexts and improve the clarity of extension settings by using more inclusive terminology that better represents the full scope of Typefully integrations.

![CleanShot 2025-03-06 at 20.30.14@2x.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/XLCshj12FUjKXyCRCqoU/2bc27f78-54ba-4dcf-8ffa-f89cf633cf82.png)

Fix MIN-16