### PR TITLE
Plug Typefully in schedule modal

### DIFF
--- a/content-scripts/src/modules/features/dynamic.js
+++ b/content-scripts/src/modules/features/dynamic.js
@@ -25,7 +25,7 @@ import changeHideViewCounts from "../options/hideViewCount";
 import { addAnalyticsButton, addCommunitiesButton, addListsButton, addTopicsButton, addXPremiumButton, hideGrokDrawer } from "../options/navigation";
 import { changeFollowingTimeline, changeRecentMedia, changeTimelineTabs, changeTrendsHomeTimeline } from "../options/timeline";
 import { changeWriterMode } from "../options/writerMode";
-import { addTypefullyComposerPlug, addTypefullyReplyPlug, saveCurrentReplyToLink, addTypefullySecurityAndAccountAccessPlug } from "../typefullyPlugs";
+import { addTypefullyComposerPlug, addTypefullyReplyPlug, saveCurrentReplyToLink, addTypefullySecurityAndAccountAccessPlug, addTypefullySchedulePlug } from "../typefullyPlugs";
 import hideRightSidebar from "../utilities/hideRightSidebar";
 import { updateLeftSidebarPositioning } from "../utilities/leftSidebarPosition";
 import { addSmallerSearchBarStyle } from "../utilities/other-styles";
@@ -47,6 +47,7 @@ export const dynamicFeatures = {
     addTypefullyReplyPlug();
     addTypefullyComposerPlug();
     addTypefullySecurityAndAccountAccessPlug();
+    addTypefullySchedulePlug();
   },
   sidebarButtons: async () => {
     const data = await getStorage([KeyListsButton, KeyCommunitiesButton, KeyTopicsButton, KeyXPremiumButton, KeyTypefullyGrowTab]);

--- a/content-scripts/src/modules/options/typefully.js
+++ b/content-scripts/src/modules/options/typefully.js
@@ -11,7 +11,8 @@ export const changeTypefullyEnhancementsButtons = (typefullyEnhancementsButtons)
         #typefully-link-inline,
         #typefully-reply-link, 
         #typefully-writermode-link, 
-        #typefully-callout-box {
+        #typefully-callout-box,
+        #typefully-schedule-button {
           display: none;
         }
         `

--- a/content-scripts/src/modules/typefullyPlugs.js
+++ b/content-scripts/src/modules/typefullyPlugs.js
@@ -9,6 +9,7 @@ import addTypefullyBox from "./utilities/addTypefullyBox";
 const MODAL_PLUG_ID = "typefully-link";
 const INLINE_PLUG_ID = "typefully-link-inline";
 const REPLY_PLUG_ID = "typefully-reply-link";
+const SCHEDULE_PLUG_ID = "typefully-schedule-link";
 
 // Function to add "Continue draft in Typefully" in the page inline composer and the modal composer
 export const addTypefullyComposerPlug = () => {
@@ -175,6 +176,43 @@ export const addTypefullySecurityAndAccountAccessPlug = () => {
   }
 };
 
+export const addTypefullySchedulePlug = () => {
+  const scheduleConfirmButton = document.querySelector('[data-testid="scheduledConfirmationPrimaryAction"]');
+
+  if (scheduleConfirmButton && !document.getElementById("typefully-schedule-button")) {
+    const scheduleButton = scheduleConfirmButton.cloneNode(true);
+
+    // remove data-testid from the scheduleButton
+    scheduleButton.removeAttribute("data-testid");
+
+    // remove any elements inside the scheduleButton
+    scheduleButton.innerHTML = "";
+
+    const element = createTypefullyLinkElement(SCHEDULE_PLUG_ID, "typefully-schedule-link");
+    const typefullyLogo = createTypefullyLogo();
+    const typefullyText = document.createElement("div");
+
+    element.addEventListener("click", () => {
+      getCurrentTextAndSendToTypefully(null, "schedule-button");
+    });
+
+    typefullyText.innerText = "Schedule with Typefully";
+    element.appendChild(typefullyLogo);
+    element.appendChild(typefullyText);
+
+    scheduleButton.appendChild(element);
+    scheduleButton.id = "typefully-schedule-button";
+
+    addTooltip(scheduleButton, {
+      id: "typefully-schedule-tooltip",
+      title: "Schedule with Typefully",
+      description: "Grow an audience faster with Typefully's social media scheduling tool.",
+    });
+
+    scheduleConfirmButton.parentElement.insertBefore(scheduleButton, scheduleConfirmButton);
+  }
+}
+
 /* ----------------------------- Typefully Utils ---------------------------- */
 
 export const createTypefullyLinkElement = (id, className) => {
@@ -194,7 +232,7 @@ export const createTypefullyLogo = () => {
   return typefullyLogo;
 };
 
-export const getCurrentTextAndSendToTypefully = (replyingToLink) => {
+export const getCurrentTextAndSendToTypefully = (replyingToLink, utm_content) => {
   let tweetTextAreaNumber = 0;
   let typefullyContent = "";
 
@@ -234,7 +272,7 @@ export const getCurrentTextAndSendToTypefully = (replyingToLink) => {
   }
 
   const url = createTypefullyUrl({
-    utm_content: "save-draft-button",
+    utm_content: utm_content ?? "save-draft-button",
     new: typefullyContent,
     ...(replyingToLink && { replyTo: replyingToLink }),
   });

--- a/css/typefully.css
+++ b/css/typefully.css
@@ -171,3 +171,23 @@ button .typefully-logo:only-child,
 [role="button"] .typefully-logo:only-child {
   margin: 0 -9px -4px 3px;
 }
+
+#typefully-schedule-button {
+  color: white;
+  background-color: var(--accent-color) !important;
+  padding-left: 22px;
+  padding-right: 22px;
+  font-weight: 700;
+  font-size: 15px;
+  font-family: TwitterChirp, -apple-system, BlinkMacSystemFont, "Segoe UI",
+    Roboto, Helvetica, Arial, sans-serif;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+}
+
+.typefully-schedule-link {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+}


### PR DESCRIPTION
### TL;DR
Added a "Schedule with Typefully" button to X's scheduling modal.

### What changed?
- Added a new "Schedule with Typefully" button in Twitter/X schedule post modal
- Implemented styling for the new schedule button to match X's design
- Added tooltip functionality to explain Typefully's scheduling benefits
- Extended the Typefully enhancements toggle to control the visibility of the schedule button

### How to test?
1. Open Twitter/X and start composing a tweet
2. Click the schedule button to open X's scheduling interface
3. Verify the new "Schedule with Typefully" button is visible
4. Hover over the button to see the tooltip
5. Click the button to ensure it redirects to Typefully with the draft content and appropriate UTM params.
6. Toggle Typefully enhancements in settings to verify the button can be hidden

### Why make this change?
To provide users with direct access to Typefully's more advanced scheduling capabilities from X's native interface, making it easier for users to leverage Typefully's growth-focused scheduling tools without leaving the X platform.

![CleanShot 2025-03-07 at 15.38.03@2x.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/XLCshj12FUjKXyCRCqoU/ef697779-5b9c-4f22-b83a-271d0d489325.png)

Fix MIN-13