### PR TITLE
Add video/photo/gif download with Typefully option

### DIFF
--- a/content-scripts/src/modules/features/dynamic.js
+++ b/content-scripts/src/modules/features/dynamic.js
@@ -23,7 +23,7 @@ import {
 } from "../../../../storage-keys";
 import changeHideViewCounts from "../options/hideViewCount";
 import { addAnalyticsButton, addCommunitiesButton, addListsButton, addTopicsButton, addXPremiumButton, hideGrokDrawer } from "../options/navigation";
-import { changeFollowingTimeline, changeRecentMedia, changeTimelineTabs, changeTrendsHomeTimeline } from "../options/timeline";
+import { changeFollowingTimeline, changeRecentMedia, changeTimelineTabs, changeTrendsHomeTimeline, addMediaDownloadButtons } from "../options/timeline";
 import { changeWriterMode } from "../options/writerMode";
 import { addTypefullyComposerPlug, addTypefullyReplyPlug, saveCurrentReplyToLink, addTypefullySecurityAndAccountAccessPlug, addTypefullySchedulePlug } from "../typefullyPlugs";
 import hideRightSidebar from "../utilities/hideRightSidebar";
@@ -41,6 +41,7 @@ export const dynamicFeatures = {
     hideRightSidebar();
     addSmallerSearchBarStyle();
     updateLeftSidebarPositioning();
+    addMediaDownloadButtons();
   },
   typefullyPlugs: () => {
     saveCurrentReplyToLink();

--- a/content-scripts/src/modules/options/timeline.js
+++ b/content-scripts/src/modules/options/timeline.js
@@ -410,8 +410,8 @@ export const addMediaDownloadButtons = () => {
 
   sharePostButtons.forEach((sharePostButton) => {
     // ensure we don't add the event listener twice
-    if (!sharePostButton.classList.contains("typefully-sharePostButton")) {
-      sharePostButton.classList.add("typefully-sharePostButton");
+    if (!sharePostButton.classList.contains("typefully-enhanced-share")) {
+      sharePostButton.classList.add("typefully-enhanced-share");
 
       sharePostButton.addEventListener("click", () => {
         const tweet = sharePostButton.closest("article[data-testid='tweet']");

--- a/content-scripts/src/modules/options/timeline.js
+++ b/content-scripts/src/modules/options/timeline.js
@@ -406,9 +406,13 @@ export const changeLatestTweets = (latestTweets) => {
 };
 
 export const addMediaDownloadButtons = () => {
-  const sharePostButtons = document.querySelectorAll("button[aria-label='Share post']");
+  const bookmarkButtons = document.querySelectorAll("button[data-testid='bookmark']");
 
-  sharePostButtons.forEach((sharePostButton) => {
+  bookmarkButtons.forEach((bookmarkButton) => {
+    const parent = bookmarkButton.parentElement;
+    const ancestor = parent?.parentElement;
+
+    const sharePostButton = ancestor.lastElementChild;
     // ensure we don't add the event listener twice
     if (!sharePostButton.classList.contains("typefully-enhanced-share")) {
       sharePostButton.classList.add("typefully-enhanced-share");

--- a/content-scripts/src/modules/options/timeline.js
+++ b/content-scripts/src/modules/options/timeline.js
@@ -2,6 +2,8 @@ import { KeyRecentMedia } from "../../../../storage-keys";
 import selectors from "../../selectors";
 import addStyles, { removeStyles, stylesExist } from "../utilities/addStyles";
 import { getStorage } from "../utilities/storage";
+import { createTypefullyLogo } from "../typefullyPlugs";
+import { createTypefullyMediaDownloadUrl } from "../utilities/createTypefullyUrl";
 
 export const changeTimelineWidth = (timelineWidth) => {
   switch (timelineWidth) {
@@ -402,3 +404,134 @@ export const changeLatestTweets = (latestTweets) => {
     showLatestTweets();
   }
 };
+
+export const addMediaDownloadButtons = () => {
+  const sharePostButtons = document.querySelectorAll("button[aria-label='Share post']");
+
+  sharePostButtons.forEach((sharePostButton) => {
+    // ensure we don't add the event listener twice
+    if (!sharePostButton.classList.contains("typefully-sharePostButton")) {
+      sharePostButton.classList.add("typefully-sharePostButton");
+
+      sharePostButton.addEventListener("click", () => {
+        const tweet = sharePostButton.closest("article[data-testid='tweet']");
+        if (!tweet) return;
+
+        const tweetLinkElements = tweet.querySelectorAll("a[href*='/status/']");
+        if (tweetLinkElements.length === 0) return;
+
+        let tweetHref;
+        let tweetUrl;
+
+        for (const tweetLinkElement of tweetLinkElements) {
+          // Pattern: /{username}/status/{postId}
+          if (tweetLinkElement.getAttribute("href").match(/\/([^\/]+)\/status\/(\d+)$/)) {
+            tweetHref = tweetLinkElement.getAttribute("href");
+            tweetUrl = tweetLinkElement.href;
+            break;
+          }
+        }
+
+        if (!tweetHref) return;
+
+        let videoTweetElement = tweet.querySelector("div[data-testid='previewInterstitial']");
+        let gifTweetElement = tweet.querySelector("button[aria-label='Play this GIF']");
+        let photoTweetElement = tweet.querySelector(`a[href*='${tweetHref}/photo']`);
+
+        let hasPhoto = false;
+        let hasVideo = false;
+        let hasGif = false;
+
+        if (tweetHref.includes('photo') || photoTweetElement) {
+          hasPhoto = true;
+        }
+
+        if (videoTweetElement) {
+          hasVideo = true;
+        }
+
+        if (gifTweetElement) {
+          hasGif = true;
+        }
+
+        // if the video tweet contains the gif tweet, make hasVideo as false.
+        if (videoTweetElement && videoTweetElement.contains(gifTweetElement)) {
+          hasVideo = false;
+        }
+
+        if (!hasVideo && !hasPhoto && !hasGif) return;
+        
+        const links = tweet.querySelectorAll("div[role='link']");
+        let quoteTweetLink;
+
+        const userName = tweet.querySelector("div[data-testid='User-Name']");
+
+        for (const link of links) {
+          if (!userName.contains(link) && link.hasAttribute("data-testid") !== "tweet-text-show-more-link") {
+            quoteTweetLink = link;
+            break;
+          }
+        }
+
+        // check if video/photo/gif is in a quote tweet.
+        // if it is, don't show the download button.
+        if (quoteTweetLink && ((quoteTweetLink.contains(videoTweetElement) || quoteTweetLink.contains(photoTweetElement)
+          || quoteTweetLink.contains(gifTweetElement)) && quoteTweetLink.hasAttribute("data-testid") !== "tweet-text-show-more-link")) return;
+
+        setTimeout(() => {
+          const dropdown = document.querySelector("div[data-testid='Dropdown']");
+          if (!dropdown) return;
+
+          const options = dropdown.querySelectorAll("div[role='menuitem']");
+          if (!options) return;
+
+          const optionToClone = options[options.length - 1];
+
+          if (hasPhoto) {
+            addDropdownOption(dropdown, "image", tweetUrl, optionToClone);
+          }
+
+          if (hasGif) {
+            addDropdownOption(dropdown, "gif", tweetUrl, optionToClone);
+          } else if (hasVideo) {
+            addDropdownOption(dropdown, "video", tweetUrl, optionToClone);
+          }
+        }, 500);
+      });
+    }
+  });
+};
+
+const addDropdownOption = (dropdown, downloadType, tweetUrl, optionToClone) => {
+  const downloadWithTypefullyOption = optionToClone.cloneNode(true);
+  downloadWithTypefullyOption.id = `typefully-${downloadType}-download-button`;
+
+  downloadWithTypefullyOption.innerHTML = "";
+
+  const typefullyLogo = createTypefullyLogo();
+  const typefullyText = document.createElement("div");
+
+  downloadWithTypefullyOption.addEventListener("click", () => {
+    let url;
+
+    if (downloadType === "gif" || downloadType === "video" || downloadType === "image") {
+      url = createTypefullyMediaDownloadUrl({
+        utm_content: `download-${downloadType}-button`,
+        tweet_url: tweetUrl,
+      }, downloadType);
+    }
+
+    window.open(url.toString());
+  });
+
+  if (downloadType === "gif") {
+    typefullyText.innerText = "Download GIF with Typefully";
+  } else {
+    typefullyText.innerText = `Download ${downloadType} with Typefully`;
+  }
+
+  downloadWithTypefullyOption.appendChild(typefullyLogo);
+  downloadWithTypefullyOption.appendChild(typefullyText);
+
+  dropdown.appendChild(downloadWithTypefullyOption);
+}

--- a/content-scripts/src/modules/options/typefully.js
+++ b/content-scripts/src/modules/options/typefully.js
@@ -12,7 +12,10 @@ export const changeTypefullyEnhancementsButtons = (typefullyEnhancementsButtons)
         #typefully-reply-link, 
         #typefully-writermode-link, 
         #typefully-callout-box,
-        #typefully-schedule-button {
+        #typefully-schedule-button,
+        #typefully-image-download-button,
+        #typefully-gif-download-button,
+        #typefully-video-download-button {
           display: none;
         }
         `

--- a/content-scripts/src/modules/utilities/createTypefullyUrl.js
+++ b/content-scripts/src/modules/utilities/createTypefullyUrl.js
@@ -11,3 +11,7 @@ export const createTypefullyUrl = (extraParams, pathname) => {
   });
   return url.toString();
 };
+
+export const createTypefullyMediaDownloadUrl = (extraParams, downloadType) => {
+  return createTypefullyUrl(extraParams, `tools/twitter-${downloadType}-downloader`);
+};

--- a/css/typefully.css
+++ b/css/typefully.css
@@ -186,6 +186,31 @@ button .typefully-logo:only-child,
   align-items: center;
 }
 
+#typefully-image-download-button,
+#typefully-gif-download-button,
+#typefully-video-download-button {
+  color: var(--accent-color);
+  font-weight: 700;
+  font-size: 15px;
+  font-family: TwitterChirp, -apple-system, BlinkMacSystemFont, "Segoe UI",
+    Roboto, Helvetica, Arial, sans-serif;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+}
+
+#typefully-image-download-button:hover,
+#typefully-gif-download-button:hover,
+#typefully-video-download-button:hover {
+  background-color: rgba(0, 0, 0, 0.03);
+}
+
+#typefully-image-download-button .typefully-logo,
+#typefully-gif-download-button .typefully-logo,
+#typefully-video-download-button .typefully-logo {
+  padding-right: 11px;
+}
+
 .typefully-schedule-link {
   display: flex;
   justify-content: center;


### PR DESCRIPTION
### TL;DR
Added video, GIF, and image download buttons to the share menu for posts containing media.

### What changed?
- Added new download options in the share menu dropdown for posts containing videos, GIFs, or images
- Each download type gets its own button with the Typefully logo
- Download buttons open media in Typefully's downloader tools
- Added styling for the new download buttons to match Twitter's UI
- Implemented checks to prevent duplicate buttons and handle quote tweets appropriately

### How to test?
1. Find a post containing a video, GIF, or image
2. Click the share button
3. Verify new download options appear in the dropdown menu
4. Click the download button and confirm it opens Typefully's downloader in a new tab
5. Verify the correct downloader opens based on media type (video/GIF/image)
6. Check that download buttons don't appear for quote tweets with media
7. Asset loading should happen automatically as soon as redirected to the corresponding tool page in Typefully tools.

### Why make this change?
To provide users with an easy way to download media content directly from Twitter posts using Typefully's downloading tools, improving the user experience for saving and sharing media content.

[CleanShot 2025-03-10 at 13.16.06.mp4 <span class="graphite__hidden">(uploaded via Graphite)</span> <img class="graphite__hidden" src="https://app.graphite.dev/api/v1/graphite/video/thumbnail/XLCshj12FUjKXyCRCqoU/e7d4ce44-1650-4bec-9168-1c353a921f80.mp4" />](https://app.graphite.dev/media/video/XLCshj12FUjKXyCRCqoU/e7d4ce44-1650-4bec-9168-1c353a921f80.mp4)

Fix MIN-14