### PR TITLE
Position the tooltip correctly on save draft in typefully button in reply and post

### DIFF
--- a/content-scripts/src/modules/utilities/addTooltip.js
+++ b/content-scripts/src/modules/utilities/addTooltip.js
@@ -29,15 +29,20 @@ ${description ? `<span class="description">${description}</span>` : ""}`;
     tooltip.classList.remove("hidden");
     const rect = element.getBoundingClientRect();
 
-    tooltip.style.top = `${rect.bottom + 10}px`;
-    tooltip.style.left = `${rect.left + rect.width / 2 - tooltip.offsetWidth / 2}px`;
+    // Account for scroll position
+    const scrollX = window.scrollX || document.documentElement.scrollLeft;
+    const scrollY = window.scrollY || document.documentElement.scrollTop;
+
+    tooltip.style.top = `${rect.bottom + scrollY + 10}px`;
+    tooltip.style.left = `${rect.left + scrollX + rect.width / 2 - tooltip.offsetWidth / 2}px`;
     tooltip.style.right = "auto";
 
     // If the tooltip is outside the viewport, move it inside with 10px margin
-    if (tooltip.offsetLeft < 10) {
-      tooltip.style.left = "10px";
+    const viewportWidth = window.innerWidth;
+    if (tooltip.offsetLeft < scrollX + 10) {
+      tooltip.style.left = `${scrollX + 10}px`;
       tooltip.style.right = "auto";
-    } else if (tooltip.offsetLeft + tooltip.offsetWidth > window.innerWidth - 10) {
+    } else if (tooltip.offsetLeft + tooltip.offsetWidth > scrollX + viewportWidth - 10) {
       tooltip.style.right = "10px";
       tooltip.style.left = "auto";
     }


### PR DESCRIPTION
### TL;DR

Fixed tooltip positioning to account for page scroll position in `Save draft in Typefully` in post and reply boxes.

### What changed?

- Added scroll position calculation to properly position tooltips when the page is scrolled
- Updated tooltip positioning logic to include scroll offsets (scrollX and scrollY)
- Improved viewport boundary checks to consider scroll position when ensuring tooltips remain visible

### How to test?

1. Scroll down on a page with tooltips
2. Hover over elements that trigger tooltips
3. Verify tooltips appear in the correct position relative to the element
4. Test near viewport edges to ensure tooltips remain visible and don't get cut off

### Why make this change?

Previously, tooltips would appear in incorrect positions when the page was scrolled because the positioning logic didn't account for scroll offsets. This fix ensures tooltips are properly positioned relative to their trigger elements regardless of scroll position.

[CleanShot 2025-03-12 at 09.58.28.mp4 <span class="graphite__hidden">(uploaded via Graphite)</span> <img class="graphite__hidden" src="https://app.graphite.dev/api/v1/graphite/video/thumbnail/XLCshj12FUjKXyCRCqoU/f6e784ba-0b4a-40c5-930b-8b9a4c19a5c7.mp4" />](https://app.graphite.dev/media/video/XLCshj12FUjKXyCRCqoU/f6e784ba-0b4a-40c5-930b-8b9a4c19a5c7.mp4)

Fix MIN-15