### PR TITLE
When grok button on a tweet is clicked on the tweet, enable grok drawer

### DIFF
--- a/content-scripts/src/modules/features/dynamic.js
+++ b/content-scripts/src/modules/features/dynamic.js
@@ -23,7 +23,7 @@ import {
 } from "../../../../storage-keys";
 import changeHideViewCounts from "../options/hideViewCount";
 import { addAnalyticsButton, addCommunitiesButton, addListsButton, addTopicsButton, addXPremiumButton, hideGrokDrawer } from "../options/navigation";
-import { changeFollowingTimeline, changeRecentMedia, changeTimelineTabs, changeTrendsHomeTimeline, addMediaDownloadButtons } from "../options/timeline";
+import { changeFollowingTimeline, changeRecentMedia, changeTimelineTabs, changeTrendsHomeTimeline, addMediaDownloadButtons, enableGrokDrawerOnGrokButtonClick } from "../options/timeline";
 import { changeWriterMode } from "../options/writerMode";
 import { addTypefullyComposerPlug, addTypefullyReplyPlug, saveCurrentReplyToLink, addTypefullySecurityAndAccountAccessPlug, addTypefullySchedulePlug } from "../typefullyPlugs";
 import hideRightSidebar from "../utilities/hideRightSidebar";
@@ -34,7 +34,7 @@ import throttle from "../utilities/throttle";
 
 export const dynamicFeatures = {
   general: async () => {
-    const data = await getStorage([KeyHideViewCount]);
+    const data = await getStorage([KeyHideViewCount, KeyHideGrokDrawer]);
 
     changeHideViewCounts(data[KeyHideViewCount]);
     changeRecentMedia();
@@ -42,6 +42,7 @@ export const dynamicFeatures = {
     addSmallerSearchBarStyle();
     updateLeftSidebarPositioning();
     addMediaDownloadButtons();
+    enableGrokDrawerOnGrokButtonClick(data[KeyHideGrokDrawer]);
   },
   typefullyPlugs: () => {
     saveCurrentReplyToLink();

--- a/content-scripts/src/modules/options/navigation.js
+++ b/content-scripts/src/modules/options/navigation.js
@@ -212,12 +212,17 @@ export const changeNavigationCenter = (navigationCenter) => {
 export const hideGrokDrawer = (state) => {
   switch (state) {
     case "on":
-      addStyles(
-        "grokDrawer",
-        `${selectors.grokDrawer} {
-          display: none !important;
-        }`
-      );
+      const grokDrawer = document.querySelector(selectors.grokDrawer);
+      // If typefully-grok-drawer-enabled class is present because we added it when grok button from a post is clicked.
+      // We don't want to hide the drawer in this case.
+      if (grokDrawer && !grokDrawer.classList.contains("typefully-grok-drawer-enabled")) {
+        addStyles(
+          "grokDrawer",
+          `${selectors.grokDrawer} {
+            display: none !important;
+          }`
+        );
+      }
       break;
     case "off":
       removeStyles("grokDrawer");

--- a/content-scripts/src/modules/options/navigation.js
+++ b/content-scripts/src/modules/options/navigation.js
@@ -212,17 +212,14 @@ export const changeNavigationCenter = (navigationCenter) => {
 export const hideGrokDrawer = (state) => {
   switch (state) {
     case "on":
-      const grokDrawer = document.querySelector(selectors.grokDrawer);
       // If typefully-grok-drawer-enabled class is present because we added it when grok button from a post is clicked.
       // We don't want to hide the drawer in this case.
-      if (grokDrawer && !grokDrawer.classList.contains("typefully-grok-drawer-enabled")) {
-        addStyles(
-          "grokDrawer",
-          `${selectors.grokDrawer} {
-            display: none !important;
-          }`
-        );
-      }
+      addStyles(
+        "grokDrawer",
+        `${selectors.grokDrawer}:not(.typefully-grok-drawer-enabled) {
+          display: none !important;
+        }`
+      );
       break;
     case "off":
       removeStyles("grokDrawer");

--- a/content-scripts/src/modules/options/timeline.js
+++ b/content-scripts/src/modules/options/timeline.js
@@ -544,7 +544,6 @@ export const enableGrokDrawerOnGrokButtonClick = (hideGrokDrawer) => {
   const grokClickListener = () => {
     const grokDrawer = document.querySelector(selectors.grokDrawer);
     grokDrawer.classList.add("typefully-grok-drawer-enabled");
-    removeStyles("grokDrawer");
   }
 
   if (hideGrokDrawer === "off") {

--- a/content-scripts/src/selectors.js
+++ b/content-scripts/src/selectors.js
@@ -35,11 +35,14 @@ selectors.accountSwitcherLabel_hover = `${selectors.accountSwitcherButton}:hover
 selectors.rightSidebar = `[data-testid="sidebarColumn"]`;
 // Add Grok drawer selector
 selectors.grokDrawer = `[data-testid="GrokDrawer"]`;
+selectors.grokDrawerHeader = `div[data-testid="GrokDrawerHeader"]`;
 // Timeline
 selectors.tweetCounts = `[role="group"][id*="id__"]:only-child`;
 selectors.viewCount = selectors.tweetCounts + " a[href*='/analytics']";
 selectors.tweet = `[data-testid="tweet"][role="article"]`;
 selectors.tweetSpan = `${selectors.tweet} div > div:only-child > span:only-child > span`;
+selectors.grokSvg = 'svg:has(path[d="M12.745 20.54l10.97-8.19c.539-.4 1.307-.244 1.564.38 1.349 3.288.746 7.241-1.938 9.955-2.683 2.714-6.417 3.31-9.83 1.954l-3.728 1.745c5.347 3.697 11.84 2.782 15.898-1.324 3.219-3.255 4.216-7.692 3.284-11.693l.008.009c-1.351-5.878.332-8.227 3.782-13.031L33 0l-4.54 4.59v-.014L12.743 20.544m-2.263 1.987c-3.837-3.707-3.175-9.446.1-12.755 2.42-2.449 6.388-3.448 9.852-1.979l3.72-1.737c-.67-.49-1.53-1.017-2.515-1.387-4.455-1.854-9.789-.931-13.41 2.728-3.483 3.523-4.579 8.94-2.697 13.561 1.405 3.454-.899 5.898-3.22 8.364C1.49 30.2.666 31.074 0 32l10.478-9.466"])';
+
 // Search
 selectors.searchBox = `${selectors.rightSidebar} form[role="search"]`;
 selectors.searchBoxInput = `${selectors.searchBox} input:only-child`;


### PR DESCRIPTION
### TL;DR

Added functionality to enable the Grok button on click while keeping the Grok drawer hidden by default.

### What changed?

- Enhanced the `hideGrokDrawer` function to add a class to track when the drawer is intentionally enabled
- Added a new `enableGrokButton` function that:
  - Allows users to click the Grok button to show the drawer even when the hide setting is on
  - Adds a class to the drawer when it's opened to prevent it from being hidden
  - Uses a ResizeObserver to detect when the drawer is closed and reapplies the hiding styles
- Added selectors for the Grok SVG icon and drawer header
- Updated the dynamic features module to load the Grok drawer setting and initialize the Grok button functionality

### How to test?

1. Enable the "Hide Grok Drawer" setting
2. Verify that the Grok drawer is hidden by default
3. Click on the Grok button from any post and confirm that the drawer appears
4. Close the drawer and verify it gets hidden again
5. Disable the "Hide Grok Drawer" setting and confirm the drawer behaves normally

### Why make this change?

This change improves user experience by allowing users to hide the Grok drawer by default but still access it when needed. Previously, when the hide setting was enabled, users couldn't access Grok functionality at all. Now they can keep the interface clean while retaining the ability to use Grok when desired.

Fix MIN-21