### PR TITLE
Update selectors for show/hide side nav labels

### DIFF
--- a/content-scripts/src/modules/features/static.js
+++ b/content-scripts/src/modules/features/static.js
@@ -23,7 +23,6 @@ import {
   KeyListsButton,
   KeyMessagesButton,
   KeyNavigationButtonsLabels,
-  KeyNavigationButtonsLabelsHover,
   KeyNavigationCenter,
   KeyNotificationsButton,
   KeyProfileButton,
@@ -67,7 +66,6 @@ import {
   changeListsButton,
   changeMessagesButton,
   changeNavigationButtonsLabels,
-  changeNavigationButtonsLabelsHover,
   changeNavigationCenter,
   changeNotificationsButton,
   changeProfileButton,
@@ -116,7 +114,6 @@ export const staticFeatures = {
   navigation: (data) => {
     changeSidebarLogo(data[KeySidebarLogo]);
     changeNavigationButtonsLabels(data[KeyNavigationButtonsLabels]);
-    changeNavigationButtonsLabelsHover(data[KeyNavigationButtonsLabelsHover]);
     changeNavigationCenter(data[KeyNavigationCenter]);
     changeUnreadCountBadge(data[KeyUnreadCountBadge]);
     hideGrokDrawer(data[KeyHideGrokDrawer]);

--- a/content-scripts/src/modules/options/navigation.js
+++ b/content-scripts/src/modules/options/navigation.js
@@ -1,10 +1,8 @@
-import { KeyNavigationButtonsLabels, KeyNavigationButtonsLabelsHover } from "../../../../storage-keys";
 import selectors from "../../selectors";
 import svgAssets from "../svgAssets";
 import addStyles, { removeStyles } from "../utilities/addStyles";
 import { createTypefullyUrl } from "../utilities/createTypefullyUrl";
 import { addSidebarButton } from "../utilities/sidebar";
-import { getStorage } from "../utilities/storage";
 
 // Utilities
 
@@ -138,52 +136,45 @@ const addStyleToRemoveLabels = () => {
   );
 };
 
-export const changeNavigationButtonsLabelsHover = async (setting) => {
-  const labelsHidden = (await getStorage(KeyNavigationButtonsLabels)) === "off";
-
-  switch (setting) {
-    case "off":
-      removeStyles("showLabelsOnHover");
-      labelsHidden && addStyleToRemoveLabels();
-      break;
-
-    case "on":
-      removeStyles("removeLabels");
-      addStyles(
-        "showLabelsOnHover",
-        `
-        ${selectors.leftSidebarLabel_hover},
-        ${selectors.accountSwitcherLabel_hover} {
-          opacity: 1;
-        }
-        `
-      );
-      break;
-  }
+const addStyleToShowLabelsOnHover = () => {
+  addStyles(
+    "hideLabels",
+    `
+    ${selectors.leftSidebarLabel},
+    ${selectors.accountSwitcherLabel} {
+      display: inline-block;
+      opacity: 0;
+      transition: 0.4s cubic-bezier(0.2, 0.8, 0.2, 1);
+    }
+    `
+  );
+  addStyles(
+    "showLabelsOnHover",
+    `
+    ${selectors.leftSidebarLabel_hover},
+    ${selectors.accountSwitcherLabel_hover} {
+      opacity: 1;
+    }
+    `
+  );
 };
 
 export const changeNavigationButtonsLabels = async (setting) => {
-  const showLabelsOnHover = (await getStorage(KeyNavigationButtonsLabelsHover)) === "on";
-
   switch (setting) {
-    case "on":
+    case "never":
+      addStyleToRemoveLabels();
+      removeStyles("showLabelsOnHover");
+
+      break;
+    case "always":
       removeStyles("hideLabels");
       removeStyles("removeLabels");
-      break;
+      removeStyles("showLabelsOnHover");
 
-    case "off":
-      !showLabelsOnHover && addStyleToRemoveLabels();
-      addStyles(
-        "hideLabels",
-        `
-        ${selectors.leftSidebarLabel},
-        ${selectors.accountSwitcherLabel} {
-          display: inline-block;
-          opacity: 0;
-          transition: 0.4s cubic-bezier(0.2, 0.8, 0.2, 1);
-        }
-        `
-      );
+      break;
+    case "hover":
+      removeStyles("removeLabels");
+      addStyleToShowLabelsOnHover();
 
       break;
   }

--- a/content-scripts/src/selectors.js
+++ b/content-scripts/src/selectors.js
@@ -28,9 +28,9 @@ selectors.sidebarLinks = {
   grok: `${selectors.leftSidebar} a[href*="grok"][role="link"][aria-label]`,
 };
 selectors.accountSwitcherButton = `[data-testid="SideNav_AccountSwitcher_Button"]`;
-selectors.leftSidebarLabel = `${selectors.leftSidebarLinks} * div + div:last-child > span:only-child`;
+selectors.leftSidebarLabel = `${selectors.leftSidebarLinks} > * > div > div + div:last-child`;
 selectors.accountSwitcherLabel = `${selectors.accountSwitcherButton} > div:not(:first-child)`;
-selectors.leftSidebarLabel_hover = `${selectors.leftSidebarLinks}:hover * div:last-child > span:only-child`;
+selectors.leftSidebarLabel_hover = `${selectors.leftSidebarLinks}:hover > * > div > div + div:last-child`;
 selectors.accountSwitcherLabel_hover = `${selectors.accountSwitcherButton}:hover > div:not(:first-child)`;
 selectors.rightSidebar = `[data-testid="sidebarColumn"]`;
 // Add Grok drawer selector

--- a/popup/components/sections/NavigationSection.js
+++ b/popup/components/sections/NavigationSection.js
@@ -13,7 +13,6 @@ import {
   KeyListsButton,
   KeyMessagesButton,
   KeyNavigationButtonsLabels,
-  KeyNavigationButtonsLabelsHover,
   KeyNavigationCenter,
   KeyNotificationsButton,
   KeyProfileButton,
@@ -23,11 +22,10 @@ import {
   KeyUnreadCountBadge,
   KeyVerifiedOrgsButton,
   KeyXPremiumButton,
-  defaultPreferences,
 } from "../../../storage-keys";
 import SectionLabel from "../ui/SectionLabel";
+import { SegmentedControl } from "../ui/SegmentedControl";
 
-import { useEffect, useState } from "react";
 import useStorageKeyState, { useStorageValue } from "../../utilities/useStorageKeyState";
 import Separator from "../ui/Separator";
 import SwitchControl from "../ui/SwitchControl";
@@ -204,11 +202,6 @@ const Jobs = () => (
 
 const NavigationSection = () => {
   const initialShowLabels = useStorageValue(KeyNavigationButtonsLabels);
-  const [labelsShown, setLabelsShown] = useState(defaultPreferences[KeyNavigationButtonsLabels] === "on");
-
-  useEffect(() => {
-    setLabelsShown(initialShowLabels === "on");
-  }, [initialShowLabels]);
 
   return (
     <section className="flex flex-col gap-y-2">
@@ -235,8 +228,26 @@ const NavigationSection = () => {
           <div className="flex flex-col gap-y-4">
             <Separator />
             <SwitchControl label="𝕏 Logo" storageKey={KeySidebarLogo} />
-            <SwitchControl label="Show Labels" storageKey={KeyNavigationButtonsLabels} onChange={setLabelsShown} />
-            <SwitchControl disabled={labelsShown} label="Show Labels on Hover" storageKey={KeyNavigationButtonsLabelsHover} />
+            <div className="flex items-center gap-x-4">
+              <span className="text-[15px] font-medium whitespace-nowrap">Show Labels</span>
+              <SegmentedControl
+                storageKey={KeyNavigationButtonsLabels}
+                segments={[
+                  {
+                    value: "never",
+                    label: "Never"
+                  },
+                  {
+                    value: "hover",
+                    label: "On Hover"
+                  },
+                  {
+                    value: "always",
+                    label: "Always"
+                  }
+                ]}
+              />
+            </div>
             <SwitchControl label="Center Vertically" storageKey={KeyNavigationCenter} />
             <SwitchControl label="Unread Count Badge" storageKey={KeyUnreadCountBadge} />
             <SwitchControl label="Hide Grok Drawer Button" storageKey={KeyHideGrokDrawer} />

--- a/popup/components/ui/SegmentedControl.js
+++ b/popup/components/ui/SegmentedControl.js
@@ -1,0 +1,86 @@
+import React, { useState, useEffect } from 'react';
+import * as TabsPrimitive from '@radix-ui/react-tabs';
+import { defaultPreferences } from '../../../storage-keys';
+import { getStorage, setStorage } from "../../utilities/chromeStorage";
+import { styled } from "@stitches/react";
+
+const StyledSegmentedControlList = styled(TabsPrimitive.List, {
+  display: 'flex',
+  width: '100%',
+  borderRadius: '8px',
+  overflow: 'hidden',
+  backgroundColor: '#e1e8ed',
+});
+
+const StyledSegmentedControlTrigger = styled(TabsPrimitive.Trigger, {
+  flex: 1,
+  padding: '4px',
+  fontSize: '14px',
+  fontWeight: 500,
+  textAlign: 'center',
+  backgroundColor: '#e1e8ed',
+  border: 'none',
+  cursor: 'pointer',
+  transition: 'all 0.2s ease',
+  color: '#536471',
+  
+  '&[data-state="active"]': {
+    backgroundColor: '#fff',
+    color: '#1da1f2',
+    fontWeight: 'bold',
+  }
+});
+
+const StyledSegmentedControlRoot = styled(TabsPrimitive.Root, {
+  width: '100%',
+  borderRadius: '8px',
+  overflow: 'hidden',
+});
+
+export const SegmentedControlList = ({ segments }) => (
+  <StyledSegmentedControlList>
+    {segments.map((segment) => (
+      <SegmentedControlTrigger key={segment.value} value={segment.value} label={segment.label} />
+    ))}
+  </StyledSegmentedControlList>
+);
+
+export const SegmentedControlTrigger = ({ value, label }) => (
+  <StyledSegmentedControlTrigger value={value}>
+    {label}
+  </StyledSegmentedControlTrigger>
+);
+
+export const SegmentedControl = ({ segments = [], storageKey }) => {
+  const [value, setValue] = useState(null);
+  
+  useEffect(() => {
+    getStorage(storageKey).then((storedValue) => {
+      if (storedValue !== undefined) {
+        setValue(storedValue);
+      } else {
+        setValue(defaultPreferences[storageKey] || (segments[0]?.value || null));
+      }
+    });
+  }, [storageKey, segments]);
+  
+  const handleValueChange = async(newValue) => {
+    setValue(newValue);
+    
+    await setStorage({ [storageKey]: newValue });
+  };
+  
+  if (segments.length === 0) {
+    return null;
+  }
+  
+  return (
+    <StyledSegmentedControlRoot 
+      value={value || segments[0].value} 
+      onValueChange={handleValueChange}
+      defaultValue={segments[0].value}
+    >
+      <SegmentedControlList segments={segments} />
+    </StyledSegmentedControlRoot>
+  );
+};

--- a/popup/package.json
+++ b/popup/package.json
@@ -16,6 +16,7 @@
     "@radix-ui/react-separator": "^0.1.3",
     "@radix-ui/react-slider": "^0.1.3",
     "@radix-ui/react-switch": "^0.1.4",
+    "@radix-ui/react-tabs": "^0.1.5",
     "@radix-ui/react-toggle": "^0.1.3",
     "@stitches/react": "^1.2.6",
     "@uiw/react-codemirror": "^4.19.6",

--- a/popup/yarn.lock
+++ b/popup/yarn.lock
@@ -433,6 +433,21 @@
     "@babel/runtime" "^7.13.10"
     "@radix-ui/react-slot" "0.1.2"
 
+"@radix-ui/react-roving-focus@0.1.5":
+  version "0.1.5"
+  resolved "https://registry.yarnpkg.com/@radix-ui/react-roving-focus/-/react-roving-focus-0.1.5.tgz#cc48d17a36b56f253d54905b0fd60ee134cb97ee"
+  integrity sha512-ClwKPS5JZE+PaHCoW7eu1onvE61pDv4kO8W4t5Ra3qMFQiTJLZMdpBQUhksN//DaVygoLirz4Samdr5Y1x1FSA==
+  dependencies:
+    "@babel/runtime" "^7.13.10"
+    "@radix-ui/primitive" "0.1.0"
+    "@radix-ui/react-collection" "0.1.4"
+    "@radix-ui/react-compose-refs" "0.1.0"
+    "@radix-ui/react-context" "0.1.1"
+    "@radix-ui/react-id" "0.1.5"
+    "@radix-ui/react-primitive" "0.1.4"
+    "@radix-ui/react-use-callback-ref" "0.1.0"
+    "@radix-ui/react-use-controllable-state" "0.1.0"
+
 "@radix-ui/react-separator@^0.1.3":
   version "0.1.4"
   resolved "https://registry.yarnpkg.com/@radix-ui/react-separator/-/react-separator-0.1.4.tgz#383ad0f82b364d9982a978d752084af3598e4090"
@@ -481,6 +496,19 @@
     "@radix-ui/react-use-controllable-state" "0.1.0"
     "@radix-ui/react-use-previous" "0.1.1"
     "@radix-ui/react-use-size" "0.1.1"
+
+"@radix-ui/react-tabs@^0.1.5":
+  version "0.1.5"
+  resolved "https://registry.yarnpkg.com/@radix-ui/react-tabs/-/react-tabs-0.1.5.tgz#ddcf860cc32e186d76477ae767dbb216d1944252"
+  integrity sha512-ieVQS1TFr0dX1XA8B+CsSFKOE7kcgEaNWWEfItxj9D1GZjn1o3WqPkW+FhQWDAWZLSKCH2PezYF3MNyO41lgJg==
+  dependencies:
+    "@babel/runtime" "^7.13.10"
+    "@radix-ui/primitive" "0.1.0"
+    "@radix-ui/react-context" "0.1.1"
+    "@radix-ui/react-id" "0.1.5"
+    "@radix-ui/react-primitive" "0.1.4"
+    "@radix-ui/react-roving-focus" "0.1.5"
+    "@radix-ui/react-use-controllable-state" "0.1.0"
 
 "@radix-ui/react-toggle@^0.1.3":
   version "0.1.4"

--- a/storage-keys.js
+++ b/storage-keys.js
@@ -23,7 +23,6 @@ export const KeyBookmarksButton = "bookmarksButton";
 export const KeyJobsButton = "jobsButton";
 export const KeyArticlesButton = "articles";
 export const KeyProfileButton = "profileButton";
-export const KeyNavigationButtonsLabelsHover = "navigationButtonsLabelsHover";
 export const KeyNavigationButtonsLabels = "navigationButtonsLabels";
 export const KeyNavigationCenter = "navigationCenter";
 export const KeyUnreadCountBadge = "unreadCountBadge";
@@ -71,7 +70,6 @@ export const allSettingsKeys = [
   // Navigation Features
   KeySidebarLogo,
   KeyNavigationButtonsLabels,
-  KeyNavigationButtonsLabelsHover,
   KeyNavigationCenter,
   KeyUnreadCountBadge,
   KeyHideGrokDrawer,
@@ -132,8 +130,7 @@ export const defaultPreferences = {
 
   // Navigation Features
   [KeySidebarLogo]: "off",
-  [KeyNavigationButtonsLabels]: "off",
-  [KeyNavigationButtonsLabelsHover]: "off",
+  [KeyNavigationButtonsLabels]: "never",
   [KeyNavigationCenter]: "off",
   [KeyUnreadCountBadge]: "off",
   [KeyHideGrokDrawer]: "on",


### PR DESCRIPTION
### TL;DR

Replaced the separate navigation label controls with a single segmented control offering three options: "Never", "On Hover", and "Always".

### What changed?

- Replaced two separate switches ("Show Labels" and "Show Labels on Hover") with a single segmented control
- Created a new `SegmentedControl` component using Radix UI tabs
- Updated the navigation label functionality to support three states: "never", "hover", and "always"
- Removed the `KeyNavigationButtonsLabelsHover` storage key as it's no longer needed
- Updated selectors to properly target navigation labels
- Added `@radix-ui/react-tabs` dependency

### How to test?

1. Open the extension popup
2. Navigate to the Navigation section
3. Test the new segmented control for navigation labels:
   - Select "Never" to hide all labels
   - Select "On Hover" to show labels only when hovering over navigation items
   - Select "Always" to always show labels

### Why make this change?

This change simplifies the user interface by consolidating two related controls into a single, more intuitive segmented control. The three distinct options make the functionality clearer to users while maintaining all the previous capabilities. The implementation is also more maintainable as it eliminates the need to manage the interaction between two separate settings.

[CleanShot 2025-03-14 at 14.56.10.mp4 <span class="graphite__hidden">(uploaded via Graphite)</span> <img class="graphite__hidden" src="https://app.graphite.dev/api/v1/graphite/video/thumbnail/XLCshj12FUjKXyCRCqoU/81ba6e9e-4a68-4517-b19e-89b9a0825def.mp4" />](https://app.graphite.dev/media/video/XLCshj12FUjKXyCRCqoU/81ba6e9e-4a68-4517-b19e-89b9a0825def.mp4)

Fix MIN-26