### PR TITLE
Reduce white space in DM's page

### DIFF
--- a/content-scripts/src/modules/features/dynamic.js
+++ b/content-scripts/src/modules/features/dynamic.js
@@ -20,9 +20,10 @@ import {
   KeyTypefullyGrowTab,
   KeyWriterMode,
   KeyXPremiumButton,
+  KeyNavigationButtonsLabels
 } from "../../../../storage-keys";
 import changeHideViewCounts from "../options/hideViewCount";
-import { addAnalyticsButton, addCommunitiesButton, addListsButton, addTopicsButton, addXPremiumButton, hideGrokDrawer } from "../options/navigation";
+import { addAnalyticsButton, addCommunitiesButton, addListsButton, addTopicsButton, addXPremiumButton, hideGrokDrawer, changeNavigationButtonsLabels } from "../options/navigation";
 import { changeFollowingTimeline, changeRecentMedia, changeTimelineTabs, changeTrendsHomeTimeline, addMediaDownloadButtons, enableGrokDrawerOnGrokButtonClick } from "../options/timeline";
 import { changeWriterMode } from "../options/writerMode";
 import { addTypefullyComposerPlug, addTypefullyReplyPlug, saveCurrentReplyToLink, addTypefullySecurityAndAccountAccessPlug, addTypefullySchedulePlug } from "../typefullyPlugs";
@@ -51,6 +52,9 @@ export const dynamicFeatures = {
     addTypefullySecurityAndAccountAccessPlug();
     addTypefullySchedulePlug();
   },
+  navigation: (data) => {
+    changeNavigationButtonsLabels(data[KeyNavigationButtonsLabels]);
+  },
   sidebarButtons: async () => {
     const data = await getStorage([KeyListsButton, KeyCommunitiesButton, KeyTopicsButton, KeyXPremiumButton, KeyTypefullyGrowTab]);
 
@@ -74,13 +78,14 @@ export const dynamicFeatures = {
 };
 
 export const runDynamicFeatures = throttle(async () => {
-  const data = await getStorage([KeyWriterMode, KeyFollowingTimeline, KeyTrendsHomeTimeline, KeyRemoveTimelineTabs, KeyHideGrokDrawer]);
+  const data = await getStorage([KeyWriterMode, KeyFollowingTimeline, KeyTrendsHomeTimeline, KeyRemoveTimelineTabs, KeyHideGrokDrawer, KeyNavigationButtonsLabels]);
 
   if (data) {
     dynamicFeatures.general();
     dynamicFeatures.typefullyPlugs();
     await dynamicFeatures.sidebarButtons();
     await dynamicFeatures.writerMode(data);
+    dynamicFeatures.navigation(data);
 
     // The Grok drawer appears dynamically, so we need to handle it here as well
     // as in the static features module

--- a/content-scripts/src/modules/options/navigation.js
+++ b/content-scripts/src/modules/options/navigation.js
@@ -3,6 +3,7 @@ import svgAssets from "../svgAssets";
 import addStyles, { removeStyles } from "../utilities/addStyles";
 import { createTypefullyUrl } from "../utilities/createTypefullyUrl";
 import { addSidebarButton } from "../utilities/sidebar";
+import { updateLeftSidebarPositioning } from "../utilities/leftSidebarPosition";
 
 // Utilities
 
@@ -132,6 +133,9 @@ const addStyleToRemoveLabels = () => {
         ${selectors.leftSidebarLinks} > * {
           max-width: 80px;
         }
+        ${selectors.accountSwitcherLabel} {
+          display: none;
+        }
         `
   );
 };
@@ -159,22 +163,76 @@ const addStyleToShowLabelsOnHover = () => {
   );
 };
 
+const addStyleToDecreaseSidebarWidthOnHover = () => {
+  addStyles(
+    "sidebarWidthDecrease",
+    `
+    @media (min-width: 1000px) {
+      main[role="main"] {
+        align-items: flex-start !important;
+      }
+    }
+    `
+  );
+};
+
+const addStyleToDecreaseSidebarWidthOnNeverShowLabels = () => {
+  addStyles(
+    "sidebarWidthDecrease",
+    `
+    @media (min-width: 1000px) {
+      ${selectors.leftSidebar} > div {
+        width: 0;
+      }
+      ${selectors.leftSidebar} {
+        position: fixed;
+      }
+      ${selectors.leftSidebar} > div > div > div {
+        width: 70px;
+      }
+    }
+    `
+  );
+};
+
 export const changeNavigationButtonsLabels = async (setting) => {
+  const isMessagesPage = window.location.pathname.startsWith("/messages");
+  const isSearchPage = window.location.pathname.startsWith("/search");
+
   switch (setting) {
     case "never":
       addStyleToRemoveLabels();
       removeStyles("showLabelsOnHover");
+      removeStyles("sidebarWidthDecrease");
 
+      if (isSearchPage) {
+        removeStyles("navigation-position");
+      }
+
+      if (isMessagesPage || isSearchPage) {
+        addStyleToDecreaseSidebarWidthOnNeverShowLabels();
+      }
       break;
     case "always":
       removeStyles("hideLabels");
       removeStyles("removeLabels");
       removeStyles("showLabelsOnHover");
+      removeStyles("sidebarWidthDecrease");
+
+      if (isMessagesPage || isSearchPage) {
+        removeStyles("navigation-position");
+      }
 
       break;
     case "hover":
       removeStyles("removeLabels");
+      removeStyles("sidebarWidthDecrease");
       addStyleToShowLabelsOnHover();
+
+      if (isMessagesPage || isSearchPage) {
+        removeStyles("navigation-position")
+        addStyleToDecreaseSidebarWidthOnHover();
+      }
 
       break;
   }

--- a/content-scripts/src/modules/utilities/leftSidebarPosition.js
+++ b/content-scripts/src/modules/utilities/leftSidebarPosition.js
@@ -1,16 +1,7 @@
 import selectors from "../../selectors";
-import addStyles, { removeStyles } from "./addStyles";
+import addStyles from "./addStyles";
 
-// This extension makes the left sidebar position fixed,
-// but in the DMs /messages and /search pages we want to revert to the default position
-// to avoid having the sidebar overlap the DMs & search interface
 export function updateLeftSidebarPositioning() {
-  const isMessagesPage = window.location.pathname.startsWith("/messages");
-  const isSearchPage = window.location.pathname.startsWith("/search");
-
-  if (isMessagesPage || isSearchPage) {
-    removeStyles("navigation-position");
-  } else {
     addStyles(
       "navigation-position",
       `@media only screen and (min-width: 1000px) {
@@ -26,5 +17,4 @@ export function updateLeftSidebarPositioning() {
         }
       }`
     );
-  }
 }

--- a/popup/components/sections/NavigationSection.js
+++ b/popup/components/sections/NavigationSection.js
@@ -26,7 +26,7 @@ import {
 import SectionLabel from "../ui/SectionLabel";
 import { SegmentedControl } from "../ui/SegmentedControl";
 
-import useStorageKeyState, { useStorageValue } from "../../utilities/useStorageKeyState";
+import useStorageKeyState from "../../utilities/useStorageKeyState";
 import Separator from "../ui/Separator";
 import SwitchControl from "../ui/SwitchControl";
 
@@ -201,8 +201,6 @@ const Jobs = () => (
 );
 
 const NavigationSection = () => {
-  const initialShowLabels = useStorageValue(KeyNavigationButtonsLabels);
-
   return (
     <section className="flex flex-col gap-y-2">
       <SectionLabel htmlFor="user-control-navigation">Left Navigation</SectionLabel>


### PR DESCRIPTION
### TL;DR

Added functionality to customize navigation button labels in the sidebar, with options to show labels always, on hover, or never.

### What changed?

- Added support for the `KeyNavigationButtonsLabels` setting to control sidebar navigation button labels
- Implemented three display modes for navigation labels: always show, show on hover, or never show
- Added special handling for the Messages page to adjust sidebar width based on the selected label mode
- Improved the styling to hide account switcher labels when labels are set to "never" show
- Added dynamic sidebar width adjustment to optimize space usage based on label visibility

### How to test?

1. Open the extension popup and navigate to the Left Navigation section
2. Try each of the three label options:
   - "Always" - Navigation labels are always visible
   - "Hover" - Labels appear when hovering over navigation items
   - "Never" - Labels are completely hidden
3. Check the Messages page specifically to verify the sidebar width adjusts correctly
4. Verify that the account switcher label is hidden when labels are set to "never"

### Why make this change?

This change gives users more control over the Twitter/X interface layout by allowing them to customize the sidebar navigation appearance. The three options provide flexibility between having full context (always showing labels), saving space (never showing labels), or a compromise between the two (showing on hover). The special handling for the Messages page ensures optimal space usage in that context.

[CleanShot 2025-03-17 at 22.27.06.mp4 <span class="graphite__hidden">(uploaded via Graphite)</span> <img class="graphite__hidden" src="https://app.graphite.dev/api/v1/graphite/video/thumbnail/XLCshj12FUjKXyCRCqoU/56b4d7cd-9171-435d-8205-1e7e3eabb353.mp4" />](https://app.graphite.dev/media/video/XLCshj12FUjKXyCRCqoU/56b4d7cd-9171-435d-8205-1e7e3eabb353.mp4)

Fix MIN-20