### PR TITLE
Don't open welcome page on extension update

### DIFF
--- a/background.js
+++ b/background.js
@@ -1,13 +1,11 @@
 // Used by the manifest v3 extension
 
 chrome.runtime.onInstalled.addListener((object) => {
-  if (object.reason !== "install" && object.reason !== "update") {
+  if (object.reason !== "install") {
     return;
   }
 
-  const targetUrl = `https://typefully.com/minimal-twitter/welcome${
-    object.reason === "update" ? "?updated=true" : ""
-  }`;
+  const targetUrl = `https://typefully.com/minimal-twitter/welcome`;
 
   if (targetUrl) {
     chrome.tabs.create({


### PR DESCRIPTION
### TL;DR

Simplified the extension's onInstalled event handler to only open the welcome page on initial installation, not on updates.

### What changed?

- Removed the condition that checks for "update" reason in the onInstalled event listener
- Removed the URL parameter `?updated=true` that was previously added for update events
- Simplified the welcome page URL to always be `https://typefully.com/minimal-twitter/welcome` without any query parameters

### How to test?

1. Install the extension for the first time and verify the welcome page opens
2. Update the extension and verify the welcome page does not open
3. Trigger other installation events and verify the welcome page does not open

### Why make this change?

This change improves user experience by only showing the welcome page to new users, preventing interruptions for existing users when the extension updates. This reduces potential annoyance from having the welcome page repeatedly open after extension updates.

Fix MIN-36